### PR TITLE
Add symengine to registry to fix R-devel Linux builds

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -72,6 +72,10 @@
     "url": "https://github.com/nlmixr2/rxode2ll"
   },
   {
+    "package": "symengine",
+    "url": "https://github.com/symengine/symengine.R"
+  },
+  {
     "package": "xpose.nlmixr2",
     "url": "https://github.com/nlmixr2/xpose.nlmixr2"
   }


### PR DESCRIPTION
symengine is a hard dependency (Imports) of nlmixr2est and nlmixr2extra (used for SAEM symbolic model generation via symengine::S), but it has no R-devel Linux binary on r-universe. That makes nlmixr2est/nlmixr2extra uninstallable on R-devel, cascading failures to nlmixr2, babelmixr2, nlmixr2plot, nlmixr2rpt, nlmixr2targets and xpose.nlmixr2.

symengine builds cleanly on all CRAN r-devel flavors, so adding it to this universe's registry lets r-universe build and host its R-devel Linux binary in-universe, satisfying the dependency.